### PR TITLE
[WIP] Feature automatic recharge on boleto subscription

### DIFF
--- a/migrations/2018-05-11-170956_add_payment_service_recharge_susbcription_function/down.sql
+++ b/migrations/2018-05-11-170956_add_payment_service_recharge_susbcription_function/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+drop function payment_service.recharge_subscription();

--- a/migrations/2018-05-11-170956_add_payment_service_recharge_susbcription_function/up.sql
+++ b/migrations/2018-05-11-170956_add_payment_service_recharge_susbcription_function/up.sql
@@ -1,0 +1,38 @@
+create or replace function payment_service.recharge_subscription(payment_service.subscriptions)
+returns payment_service.catalog_payments 
+language plpgsql 
+as $$
+    declare
+        _last_payment payment_service.catalog_payments;
+        _generated_payment payment_service.catalog_payments;
+    begin
+        -- get last payment from subscription
+        select * from payment_service.catalog_payments
+            where subscription_id = $1.id order by created_at desc
+            limit 1 into _last_payment;
+
+        -- if last payment is pending and is a boleto
+        if _last_payment.status = 'pending' and $1.checkout_data->> 'payment_method'::text  = 'boleto' then
+            -- if boleto expiration date already in past turn payment to refused and generate a new payment for subscription
+            if (_last_payment.gateway_general_data->>'boleto_expiration_date')::date <= now()::date then
+                -- turn current payment to refused
+                if payment_service.transition_to(_last_payment, 'refused', row_to_json(_last_payment)) then
+                    -- generate a new payment
+                    _generated_payment := payment_service.generate_new_catalog_payment($1);
+                end if;
+            else
+                -- return last payment when still not expired
+                _generated_payment := _last_payment;
+            end if;
+        -- if last payment is refused should generate new payment
+        elsif _last_payment.status = 'refused' then
+            -- generate a new payment
+            _generated_payment := payment_service.generate_new_catalog_payment($1);
+        -- when not match with any conditions should return the last payment
+        else
+            _generated_payment := _last_payment;
+        end if;
+
+        return _generated_payment;
+    end;
+$$;

--- a/migrations/2018-05-11-171239_update_refuse_expired_slip_payments_to_wait_limit_before_invalidate_subscription/down.sql
+++ b/migrations/2018-05-11-171239_update_refuse_expired_slip_payments_to_wait_limit_before_invalidate_subscription/down.sql
@@ -1,0 +1,74 @@
+-- This file should undo anything in `up.sql`
+CREATE OR REPLACE FUNCTION payment_service.refuse_expired_slip_payments()
+ RETURNS json
+ LANGUAGE plpgsql
+AS $function$
+        declare
+            _payment payment_service.catalog_payments;
+            _last_subscription_payment payment_service.catalog_payments;
+            _last_paid_subscription_payment payment_service.catalog_payments;
+            _subscription payment_service.subscriptions;
+            _result json;
+            _affected_subscriptions_ids uuid[];
+            _total_affected_subscriptions integer default 0;
+            _affected_payments_ids uuid[];
+            _total_affected_payments integer default 0;        
+        begin
+            -- get all boleto that already expired +3 days from expiration date
+            for _payment in (select cp.*
+                from payment_service.catalog_payments cp
+                where data ->> 'payment_method' = 'boleto' and cp.status = 'pending'
+                    and (cp.gateway_general_data ->> 'boleto_expiration_date')::timestamp is not null
+                    and core.weekdays_from(3, (cp.gateway_general_data ->> 'boleto_expiration_date')::timestamp) < now()
+            )
+            loop 
+                -- if payment is from subscription
+                if _payment.subscription_id is not null then
+                    -- get last payment from subscription
+                    select * from payment_service.catalog_payments
+                        where subscription_id = _payment.subscription_id
+                            order by created_at desc limit 1
+                            into _last_subscription_payment;
+                    -- get last paid payment from subscription
+                    select * from payment_service.catalog_payments
+                        where subscription_id = _payment.subscription_id
+                            and status = 'paid'
+                            order by created_at desc limit 1
+                            into _last_paid_subscription_payment;                    
+        
+                    -- get subscription
+                    select * from payment_service.subscriptions
+                        where id = _payment.subscription_id
+                        into _subscription;
+                end if;
+                
+                -- transition payment to refused 
+                if payment_service.transition_to(_payment, 'refused', row_to_json(_payment.*)) then
+                    _total_affected_payments := _total_affected_payments + 1;
+                    _affected_payments_ids := array_append(_affected_payments_ids, _payment.id);
+                    
+                    -- if payment is the same of last_payment
+                    if _payment.id = _last_subscription_payment.id 
+                        and _last_paid_subscription_payment.id is null OR (
+                            _last_paid_subscription_payment.created_at + (core.get_setting('subscription_interval'))::interval
+                        ) <= now()
+                    then
+                        -- then transition subscription to inactive too
+                        if payment_service.transition_to(_subscription, 'inactive', row_to_json(_subscription.*)) then
+                            _total_affected_subscriptions := _total_affected_subscriptions + 1;
+                            _affected_subscriptions_ids := array_append(_affected_subscriptions_ids, _subscription.id);                
+                        end if;
+                    end if;
+                end if;
+            end loop;
+            
+            _result := json_build_object(
+                'total_subscriptions_affected', _total_affected_subscriptions,
+                'affected_subscriptions_ids', _affected_subscriptions_ids,
+                'total_payments_affected', _total_affected_payments,
+                'affected_payments_ids', _affected_payments_ids                
+            );
+
+            return _result;    
+        end;
+    $function$

--- a/migrations/2018-05-11-171239_update_refuse_expired_slip_payments_to_wait_limit_before_invalidate_subscription/up.sql
+++ b/migrations/2018-05-11-171239_update_refuse_expired_slip_payments_to_wait_limit_before_invalidate_subscription/up.sql
@@ -1,0 +1,106 @@
+-- Your SQL goes here
+CREATE OR REPLACE FUNCTION payment_service.refuse_expired_slip_payments()
+ RETURNS json
+ LANGUAGE plpgsql
+AS $function$
+        declare
+            _payment payment_service.catalog_payments;
+            _last_subscription_payment payment_service.catalog_payments;
+            _last_paid_subscription_payment payment_service.catalog_payments;
+            _subscription payment_service.subscriptions;
+            _result json;
+            _affected_subscriptions_ids uuid[];
+            _total_affected_subscriptions integer default 0;
+            _affected_payments_ids uuid[];
+            _total_affected_payments integer default 0;
+            _should_transit_subscription_to_inactive boolean default true;
+            _recharged_payment payment_service.catalog_payments;
+            _recharged_payment_ids uuid[];
+        begin
+            -- get all boleto that already expired +3 days from expiration date
+            for _payment in (select cp.*
+                from payment_service.catalog_payments cp
+                where data ->> 'payment_method' = 'boleto' and cp.status = 'pending'
+                    and (cp.gateway_general_data ->> 'boleto_expiration_date')::timestamp is not null
+                    and core.weekdays_from(3, (cp.gateway_general_data ->> 'boleto_expiration_date')::timestamp) < now()
+            )
+            loop 
+                -- if payment is from subscription
+                if _payment.subscription_id is not null then
+                    -- get last payment from subscription
+                    select * from payment_service.catalog_payments
+                        where subscription_id = _payment.subscription_id
+                            order by created_at desc limit 1
+                            into _last_subscription_payment;
+                    -- get last paid payment from subscription
+                    select * from payment_service.catalog_payments
+                        where subscription_id = _payment.subscription_id
+                            and status = 'paid'
+                            order by created_at desc limit 1
+                            into _last_paid_subscription_payment;
+
+                    -- get subscription
+                    select * from payment_service.subscriptions
+                        where id = _payment.subscription_id
+                        into _subscription;
+                end if;
+
+                -- transition payment to refused 
+                if payment_service.transition_to(_payment, 'refused', row_to_json(_payment.*)) then
+
+                    _total_affected_payments := _total_affected_payments + 1;
+                    _affected_payments_ids := array_append(_affected_payments_ids, _payment.id);
+
+                    if _subscription.id is not null then
+                        if _last_paid_subscription_payment.id is not null then
+                            _should_transit_subscription_to_inactive := (
+                                select count(1) >= 3 
+                                from payment_service.catalog_payments 
+                                where status in ('refused', 'pending')
+                                    and subscription_id = _last_paid_subscription_payment.subscription_id
+                                    and created_at > _last_paid_subscription_payment.created_at
+                                    and id <> _last_paid_subscription_payment.id
+                            );
+                        else
+                            _should_transit_subscription_to_inactive := (
+                                select count(1) >= 2
+                                from payment_service.catalog_payments 
+                                where status in ('refused', 'pending')
+                                    and subscription_id = _last_subscription_payment.subscription_id
+                                    and created_at > _last_subscription_payment.created_at
+                                    and id <> _last_subscription_payment.id
+                            );
+                        end if;
+
+                        -- if payment is the same of last_payment
+                        if _payment.id = _last_subscription_payment.id 
+                            and _last_paid_subscription_payment.id is null OR (
+                                _last_paid_subscription_payment.created_at + (core.get_setting('subscription_interval'))::interval
+                            ) <= now()
+                        then
+                            -- should generate new payment while _should_transit_subscription_to_inactive is false
+                            if _should_transit_subscription_to_inactive then
+                                if payment_service.transition_to(_subscription, 'inactive', row_to_json(_subscription.*)) then
+                                    _total_affected_subscriptions := _total_affected_subscriptions + 1;
+                                    _affected_subscriptions_ids := array_append(_affected_subscriptions_ids, _subscription.id);                
+                                end if;
+                            else
+                                _recharged_payment := payment_service.recharge_subscription(_subscription);
+                                _recharged_payment_ids := array_append(_recharged_payment_ids, _recharged_payment.id);
+                            end if;
+                        end if;
+                    end if;
+                end if;
+            end loop;
+
+            _result := json_build_object(
+                'total_subscriptions_affected', _total_affected_subscriptions,
+                'affected_subscriptions_ids', _affected_subscriptions_ids,
+                'total_payments_affected', _total_affected_payments,
+                'affected_payments_ids', _affected_payments_ids,
+                'recharged_payment_ids', _recharged_payment_ids
+            );
+
+            return _result;
+        end;
+    $function$;

--- a/specs/sql-specs/payment-service/function.recharge_subscription_test.sql
+++ b/specs/sql-specs/payment-service/function.recharge_subscription_test.sql
@@ -1,0 +1,69 @@
+BEGIN;
+    -- insert seed data for basic user/platform/project/reward
+    \i /specs/sql-support/insert_platform_user_project.sql
+
+    select plan(5);
+
+    select function_returns('payment_service', 'recharge_subscription', '{payment_service.subscriptions}'::text[], 'payment_service.catalog_payments');
+
+    create or replace function test_recharge_boleto_subscription_in_time()
+    returns setof text language plpgsql
+    as $$
+    declare
+    _payment payment_service.catalog_payments;
+    _recharge_payment payment_service.catalog_payments;
+    _subscription payment_service.subscriptions;
+    begin
+        -- generate subscription
+        insert into payment_service.subscriptions
+        (status, created_at, platform_id, user_id, project_id, checkout_data) 
+        values ('active', (now() - '15 days'::interval), __seed_platform_id(), __seed_first_user_id(), __seed_project_id(), '{}'::jsonb)
+        returning * into _subscription;
+
+        -- generate payment
+        insert into payment_service.catalog_payments
+        (status, created_at, gateway, platform_id, user_id, project_id, data, subscription_id, gateway_general_data) 
+        values ('pending', (now() - '1 days'::interval), 'pagarme', __seed_platform_id(), __seed_first_user_id(), __seed_project_id(), json_build_object('payment_method', 'boleto'), _subscription.id, json_build_object('boleto_expiration_date', now() + '3 days'::interval)::jsonb)
+        returning * into _payment;
+
+        _recharge_payment := payment_service.recharge_subscription(_subscription);
+
+        return next is(_payment.id, _recharge_payment.id, 'should not generate another payment and return the same');
+    end;
+    $$;
+    select * from test_recharge_boleto_subscription_in_time();
+
+    create or replace function test_recharge_boleto_subscription_with_pending_payment_expired()
+    returns setof text language plpgsql
+    as $$
+    declare
+    _payment payment_service.catalog_payments;
+    _recharge_payment payment_service.catalog_payments;
+    _subscription payment_service.subscriptions;
+    begin
+        -- generate subscription
+        insert into payment_service.subscriptions
+        (status, created_at, platform_id, user_id, project_id, checkout_data) 
+        values ('active', (now() - '15 days'::interval), __seed_platform_id(), __seed_first_user_id(), __seed_project_id(), json_build_object('payment_method', 'boleto')::jsonb)
+        returning * into _subscription;
+
+        -- generate payment
+        insert into payment_service.catalog_payments
+        (status, created_at, gateway, platform_id, user_id, project_id, data, subscription_id, gateway_general_data) 
+        values ('pending', (now() - '1 days'::interval), 'pagarme', __seed_platform_id(), __seed_first_user_id(), __seed_project_id(), json_build_object('payment_method', 'boleto'), _subscription.id, json_build_object('boleto_expiration_date', now() - '1 days'::interval)::jsonb)
+        returning * into _payment;
+
+        _recharge_payment := payment_service.recharge_subscription(_subscription);
+        
+        -- reload payment
+        select * from payment_service.catalog_payments
+            where id = _payment.id into _payment;
+
+        return next ok(_payment.id <> _recharge_payment.id, 'should generate a new payment for subscription');
+        return next is(_payment.status, 'refused', 'should turn previus payment to refused');
+        return next is(_recharge_payment.status, 'pending', 'should generate a new payment with pending');
+    end;
+    $$;
+    select * from test_recharge_boleto_subscription_with_pending_payment_expired();
+
+    ROLLBACK;

--- a/specs/sql-specs/payment-service/function.refuse_expired_slip_payments_test.sql
+++ b/specs/sql-specs/payment-service/function.refuse_expired_slip_payments_test.sql
@@ -3,7 +3,7 @@ BEGIN;
     -- insert seed data for basic user/platform/project/reward
     \i /specs/sql-support/insert_platform_user_project.sql
 
-    SELECT plan(18);
+    SELECT plan(28);
 
     SELECT function_returns('payment_service', 'refuse_expired_slip_payments', '{}'::text[], 'json');
 
@@ -104,13 +104,14 @@ BEGIN;
     select * from test_not_inactive_ative_subscription_in_time();
 
 
-    create or replace function test_inactive_ative_subscription_expired()
+    create or replace function test_inactive_active_subscription_expired()
     returns setof text language plpgsql
     as $$
         declare
             _active_subscription payment_service.subscriptions;
             _expired_payment payment_service.catalog_payments;
             _paid_not_in_time payment_service.catalog_payments;
+            _recharged_payment payment_service.catalog_payments;
             _result json;
         begin
 
@@ -143,19 +144,87 @@ BEGIN;
                 where id = _expired_payment.id
                 into _expired_payment;
 
+            select * from payment_service.catalog_payments
+                where id = (_result -> 'recharged_payment_ids' ->> 0)::uuid
+                limit 1
+                into _recharged_payment;
+
+            return next is((_result ->> 'total_subscriptions_affected')::integer, 0);
+            return next is(((_result ->> 'affected_subscriptions_ids')::json->>0), null);
+            return next is((_result ->> 'total_payments_affected')::integer , 1);
+            return next is(((_result ->> 'affected_payments_ids')::json->>0)::uuid, _expired_payment.id);
+            return next is(json_array_length((_result->'recharged_payment_ids')), 1);
+
+            return next is(_active_subscription.status, 'active', 'should keep subscription active until reach recharge limit');
+            return next is(_paid_not_in_time.status, 'paid');
+            return next is(_expired_payment.status, 'refused');
+            return next is(_recharged_payment.status, 'pending');
+        end;
+    $$;
+
+    select * from test_inactive_active_subscription_expired();
+
+
+
+    create or replace function test_inactive_active_subscription_reach_limit()
+    returns setof text language plpgsql
+    as $$
+        declare
+            _active_subscription payment_service.subscriptions;
+            _expired_payment payment_service.catalog_payments;
+            _paid_not_in_time payment_service.catalog_payments;
+            _recharged_payment payment_service.catalog_payments;
+            _result json;
+        begin
+
+            -- generate subscription
+            insert into payment_service.subscriptions
+                (status, created_at, platform_id, user_id, project_id, checkout_data) 
+                values ('active', (now() - '2 months'::interval), __seed_platform_id(), __seed_first_user_id(), __seed_project_id(), '{}'::jsonb)
+                returning * into _active_subscription;
+
+            -- generate payments
+            insert into payment_service.catalog_payments
+                (status, created_at, gateway, platform_id, user_id, project_id, data, subscription_id) 
+                values ('paid', (now() - '1 month'::interval), 'pagarme', __seed_platform_id(), __seed_first_user_id(), __seed_project_id(), json_build_object('payment_method', 'boleto'), _active_subscription.id)
+                returning * into _paid_not_in_time;
+
+            insert into payment_service.catalog_payments
+                (status, created_at, gateway, platform_id, user_id, project_id, data, subscription_id, gateway_general_data) 
+                values ('refused', (now() - '2 days'::interval), 'pagarme', __seed_platform_id(), __seed_first_user_id(), __seed_project_id(), json_build_object('payment_method', 'boleto'), _active_subscription.id, json_build_object('boleto_expiration_date', now() - '2 days'::interval)::jsonb),
+                ('refused', (now() - '4 days'::interval), 'pagarme', __seed_platform_id(), __seed_first_user_id(), __seed_project_id(), json_build_object('payment_method', 'boleto'), _active_subscription.id, json_build_object('boleto_expiration_date', now() - '4 days'::interval)::jsonb);
+
+            insert into payment_service.catalog_payments
+                (status, created_at, gateway, platform_id, user_id, project_id, data, subscription_id, gateway_general_data) 
+                values ('pending', (now() - '10 days'::interval), 'pagarme', __seed_platform_id(), __seed_first_user_id(), __seed_project_id(), json_build_object('payment_method', 'boleto'), _active_subscription.id, json_build_object('boleto_expiration_date', now() - '9 days'::interval)::jsonb)
+                returning * into _expired_payment;
+
+            _result := payment_service.refuse_expired_slip_payments();
+            -- reload subscription and payments
+            select * from payment_service.subscriptions
+                where id = _active_subscription.id
+                into _active_subscription;
+            select * from payment_service.catalog_payments
+                where id = _paid_not_in_time.id
+                into _paid_not_in_time;
+            select * from payment_service.catalog_payments
+                where id = _expired_payment.id
+                into _expired_payment;
+
+
             return next is((_result ->> 'total_subscriptions_affected')::integer, 1);
             return next is(((_result ->> 'affected_subscriptions_ids')::json->>0)::uuid, _active_subscription.id);
             return next is((_result ->> 'total_payments_affected')::integer , 1);
             return next is(((_result ->> 'affected_payments_ids')::json->>0)::uuid, _expired_payment.id);
+            return next is((_result->>'recharged_payment_ids'), null);
 
-            return next is(_active_subscription.status, 'inactive');
+            return next is(_active_subscription.status, 'inactive', 'should inactive subscription after reach limit of recharges');
             return next is(_paid_not_in_time.status, 'paid');
             return next is(_expired_payment.status, 'refused');
         end;
     $$;
 
-    select * from test_inactive_ative_subscription_expired();
-
+    select * from test_inactive_active_subscription_reach_limit();
 
     SELECT * FROM finish();
 ROLLBACK;


### PR DESCRIPTION
- add function to recharge a subscription (just generate a new payment when last payment is not paid)
- update refuse_expired_slip to only inactive the subscription when already reached the limit of pending / refused payments after the last paid

TODO
- add api route to user can request a recharge without change the subscription status 
- update inactive_invalid_subscriptions to not inactive until reach automatic recharge limit