### PR TITLE
add missing index on catalog_payments(subscription_id, status)

### DIFF
--- a/migrations/2018-05-23-175302_add_index_to_subscription_id_and_status_on_catalog_payments/down.sql
+++ b/migrations/2018-05-23-175302_add_index_to_subscription_id_and_status_on_catalog_payments/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+drop index payment_service.idx_payment_subscription_id_and_status;

--- a/migrations/2018-05-23-175302_add_index_to_subscription_id_and_status_on_catalog_payments/up.sql
+++ b/migrations/2018-05-23-175302_add_index_to_subscription_id_and_status_on_catalog_payments/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+create index idx_payment_subscription_id_and_status on payment_service.catalog_payments(subscription_id, status);


### PR DESCRIPTION
### Why

Endpoint that list subscription are very slow because of missing indexes when used to count on catalog_payments by status and subscription_id

### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
