### PR TITLE
add common_docs service to expose mdbook docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -338,3 +338,16 @@ services:
       cluster:
         ipv4_address: 10.0.1.58
 
+
+  common_docs:
+    image: hrektts/mdbook
+    volumes:
+      - ../common/:/data
+    ports:
+      - "3011:3011"
+      - "3012:3012"
+    command: ["mdbook", "serve", "-p", "3011", "-w", "3012", "-i", "0.0.0.0"]
+    networks:
+      cluster:
+        ipv4_address: 10.0.1.60
+


### PR DESCRIPTION
### Why

Add mdbook server running for docs

DOCs PR => https://github.com/common-group/common/pull/8

### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [x] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
