### PR TITLE
Generate internal tokens from another api keys

### DIFF
--- a/migrations/2018-08-02-161136_add_contribution_functions/down.sql
+++ b/migrations/2018-08-02-161136_add_contribution_functions/down.sql
@@ -1,0 +1,5 @@
+-- This file should undo anything in `up.sql`
+
+DROP FUNCTION payment_service.confirmed_states();
+DROP FUNCTION payment_service.was_confirmed(payment_service.contributions);
+DROP FUNCTION payment_service.is_confirmed(payment_service.contributions);

--- a/migrations/2018-08-02-161136_add_contribution_functions/up.sql
+++ b/migrations/2018-08-02-161136_add_contribution_functions/up.sql
@@ -1,0 +1,39 @@
+-- Your SQL goes here
+
+CREATE OR REPLACE FUNCTION payment_service.confirmed_states()
+ RETURNS payment_service.payment_status[]
+ LANGUAGE sql
+AS $function$
+      SELECT '{"paid", "pending_refund", "refunded"}'::payment_service.payment_status[];
+    $function$;
+
+COMMENT ON FUNCTION payment_service.confirmed_states() is 'payment states that are considered confirmed';
+
+CREATE OR REPLACE FUNCTION payment_service.was_confirmed(payment_service.contributions)
+ RETURNS boolean
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+AS $function$
+            SELECT EXISTS (
+              SELECT true
+              FROM
+                payment_service.catalog_payments p
+              WHERE p.contribution_id = $1.id AND p.status = ANY(payment_service.confirmed_states())
+            );
+          $function$;
+
+COMMENT ON FUNCTION payment_service.was_confirmed(payment_service.contributions) is 'returns true if contribution was paid once';
+
+CREATE OR REPLACE FUNCTION payment_service.is_confirmed(payment_service.contributions)
+ RETURNS boolean
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+AS $function$
+      SELECT EXISTS (
+        SELECT true
+        FROM
+          payment_service.catalog_payments p
+        WHERE p.contribution_id = $1.id AND p.status = 'paid'::payment_service.payment_status
+      );
+    $function$;
+COMMENT ON FUNCTION payment_service.is_confirmed(payment_service.contributions) is 'returns true if contribution is paid';

--- a/migrations/2018-08-06-174442_adjust_generate_access_jwt_to_work_with_another_tokens/down.sql
+++ b/migrations/2018-08-06-174442_adjust_generate_access_jwt_to_work_with_another_tokens/down.sql
@@ -1,0 +1,32 @@
+-- This file should undo anything in `up.sql`
+CREATE OR REPLACE FUNCTION core.generate_access_jwt_from_api_key(api_key text)
+ RETURNS text
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+    declare
+        _platform_api platform_service.platform_api_keys;
+        _platform platform_service.platforms;
+
+        _token text;
+    begin
+        select * from platform_service.platform_api_keys
+            where token = $1
+            into _platform_api;
+        select * from platform_service.platforms
+            where id = _platform_api.platform_id
+            into _platform;
+        
+        if _platform.id is not null
+            and _platform_api.id is not null then
+            select token from core.gen_jwt_token(json_build_object(
+                'role', 'platform_user',
+                'platform_token', _platform.token,
+                'exp', extract(epoch from (now() + '60 seconds'))::integer,
+                'iat', extract(epoch from now())::integer
+            )) into _token;
+        end if;
+        
+        return _token;
+    end;
+$function$;

--- a/migrations/2018-08-06-174442_adjust_generate_access_jwt_to_work_with_another_tokens/up.sql
+++ b/migrations/2018-08-06-174442_adjust_generate_access_jwt_to_work_with_another_tokens/up.sql
@@ -1,0 +1,85 @@
+-- Your SQL goes here
+CREATE OR REPLACE FUNCTION core.generate_access_jwt_from_api_key(api_key text)
+ RETURNS text
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+    declare
+        _platform_api platform_service.platform_api_keys;
+        _temp_login_api_key community_service.temp_login_api_keys;
+        _user_api_key community_service.user_api_keys;
+
+        _platform platform_service.platforms;
+        _token text;
+        _scopes jsonb;
+    begin
+        case
+        when $1 ~ '^platform_api_key_(\w+)$' then
+            -- when platform api key token should look on platform_api_keys
+            select * from platform_service.platform_api_keys
+                where token = $1
+                into _platform_api;
+
+            select * from platform_service.platforms
+                where id = _platform_api.platform_id
+                into _platform;
+
+            if _platform.id is not null
+                and _platform_api.id is not null then
+                select token from core.gen_jwt_token(json_build_object(
+                    'role', 'platform_user',
+                    'platform_token', _platform.token,
+                    'exp', extract(epoch from (now() + '60 seconds'))::integer
+                )) into _token;
+            end if;
+        when $1 ~ '^temp_login_api_key_(\w+)$' then
+            -- when temp login api key token should look on platform_api_keys
+            select * from community_service.temp_login_api_keys
+                where token = $1 and expires_at > now()
+                into _temp_login_api_key;
+            select * from platform_service.platforms
+                where id = _temp_login_api_key.platform_id
+                into _platform;
+
+            if _platform.id is not null
+                and _temp_login_api_key.id is not null then
+                select to_jsonb(array_agg(role_name)) from community_service.user_roles
+                    where user_id = _temp_login_api_key.user_id
+                    and platform_id = _platform.id
+                    into _scopes;
+                select token from core.gen_jwt_token(json_build_object(
+                    'role', 'scoped_user',
+                    'user_id', _temp_login_api_key.user_id,
+                    'platform_token', _platform.token,
+                    'exp', extract(epoch from (now() + '60 seconds'))::integer,
+                    'scopes', _scopes
+                )) into _token;
+            end if;
+        when $1 ~ '^user_api_key_(\w+)$' then
+            -- when temp login api key token should look on platform_api_keys
+            select * from community_service.user_api_keys
+                where token = $1 and disabled_at is null
+                into _user_api_key;
+            select * from platform_service.platforms
+                where id = _user_api_key.platform_id
+                into _platform;
+
+            if _platform.id is not null
+                and _user_api_key.id is not null then
+                select to_jsonb(array_agg(role_name)) from community_service.user_roles
+                    where user_id = _user_api_key.user_id
+                    and platform_id = _platform.id
+                    into _scopes;
+                select token from core.gen_jwt_token(json_build_object(
+                    'role', 'scoped_user',
+                    'user_id', _user_api_key.user_id,
+                    'platform_token', _platform.token,
+                    'exp', extract(epoch from (now() + '60 seconds'))::integer,
+                    'scopes', _scopes
+                )) into _token;
+            end if;
+        else
+        end case;
+        return _token;
+    end;
+$function$;

--- a/specs/sql-specs/core/function.generate_access_jwt_from_api_key_test.sql
+++ b/specs/sql-specs/core/function.generate_access_jwt_from_api_key_test.sql
@@ -1,11 +1,13 @@
 BEGIN;
     \i /specs/sql-support/insert_platform_user_project.sql
-    select plan(4);
+    select plan(16);
 
     select function_returns('core', 'generate_access_jwt_from_api_key', ARRAY['text'], 'text');
 
     insert into core.core_settings(name, value)
         values ('jwt_secret', 'gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr9C');
+
+    insert into community_service.user_roles(user_id, platform_id, role_name) values (__seed_first_user_id(), __seed_platform_id(), 'admin');
 
     create or replace function test_with_platform_api_key()
     returns setof text language plpgsql as $$
@@ -16,10 +18,10 @@ BEGIN;
         begin
             select * from platform_service.platforms where id = __seed_platform_id() into _platform;
 
-            insert into platform_service.platform_api_keys(platform_id, token) values (_platform.id, 'abcdapi');
-            _result := core.generate_access_jwt_from_api_key('abcdapi');
+            insert into platform_service.platform_api_keys(platform_id, token) values (__seed_platform_id(), 'platform_api_key_f473386b7962189c512a82e419c824d64fa89c4034a22904fd608913fbccc913d224a859149700ff0850af56a343fdb24b90');
+            _result := core.generate_access_jwt_from_api_key('platform_api_key_f473386b7962189c512a82e419c824d64fa89c4034a22904fd608913fbccc913d224a859149700ff0850af56a343fdb24b90');
             select payload 
-            from core.verify(_result::text, core.get_setting('jwt_secret')::text, 'HS512')
+            from core.verify(_result::text, core.get_setting('jwt_secret')::text, 'HS256')
             into _decoded_payload;
 
             return next is ((_decoded_payload->>'platform_token')::uuid, _platform.token);
@@ -28,6 +30,90 @@ BEGIN;
         end;
     $$;
     select test_with_platform_api_key();
+
+
+    create or replace function test_with_temp_login_api_key()
+    returns setof text language plpgsql as $$
+        declare
+            _platform platform_service.platforms;
+            _result text;
+            _decoded_payload json;
+        begin
+            select * from platform_service.platforms where id = __seed_platform_id() into _platform;
+
+            insert into community_service.temp_login_api_keys(expires_at, user_id, platform_id, token) values ((now() + '2 days'::interval), __seed_first_user_id(), __seed_platform_id(), 'temp_login_api_key_f473386b7962189c512a82e419c824d64fa89c4034a22904fd608913fbccc913d224a859149700ff0850af56a343fdb24b90');
+            _result := core.generate_access_jwt_from_api_key('temp_login_api_key_f473386b7962189c512a82e419c824d64fa89c4034a22904fd608913fbccc913d224a859149700ff0850af56a343fdb24b90');
+            select payload 
+            from core.verify(_result::text, core.get_setting('jwt_secret')::text, 'HS256')
+            into _decoded_payload;
+
+            return next is ((_decoded_payload->>'platform_token')::uuid, _platform.token);
+            return next is ((_decoded_payload->>'role')::text, 'scoped_user');
+            return next is ((_decoded_payload->>'user_id')::uuid, __seed_first_user_id());
+            return next is ((_decoded_payload->>'scopes')::jsonb, to_jsonb('{admin}'::text[]));
+            return next is ((_result is not null), true);
+        end;
+    $$;
+    select test_with_temp_login_api_key();
+
+
+    create or replace function test_with_expired_temp_login_api_key()
+    returns setof text language plpgsql as $$
+        declare
+            _platform platform_service.platforms;
+            _result text;
+            _decoded_payload json;
+        begin
+            select * from platform_service.platforms where id = __seed_platform_id() into _platform;
+
+            insert into community_service.temp_login_api_keys(expires_at, user_id, platform_id, token) values ((now() - '2 days'::interval), __seed_first_user_id(), _platform.id, 'temp_login_api_key_exp3386b7962189c512a82e419c824d64fa89c4034a22904fd608913fbccc913d224a859149700ff0850af56a343fdb24b90');
+            _result := core.generate_access_jwt_from_api_key('temp_login_api_key_exp3386b7962189c512a82e419c824d64fa89c4034a22904fd608913fbccc913d224a859149700ff0850af56a343fdb24b90');
+
+            return next is ((_result is null), true);
+        end;
+    $$;
+    select test_with_expired_temp_login_api_key();
+
+    create or replace function test_with_user_api_key()
+    returns setof text language plpgsql as $$
+        declare
+            _platform platform_service.platforms;
+            _result text;
+            _decoded_payload json;
+        begin
+            select * from platform_service.platforms where id = __seed_platform_id() into _platform;
+
+            insert into community_service.user_api_keys(user_id, platform_id, token) values (__seed_first_user_id(), _platform.id, 'user_api_key_f473386b7962189c512a82e419c824d64fa89c4034a22904fd608913fbccc913d224a859149700ff0850af56a343fdb24b90');
+            _result := core.generate_access_jwt_from_api_key('user_api_key_f473386b7962189c512a82e419c824d64fa89c4034a22904fd608913fbccc913d224a859149700ff0850af56a343fdb24b90');
+            select payload 
+            from core.verify(_result::text, core.get_setting('jwt_secret')::text, 'HS256')
+            into _decoded_payload;
+
+            return next is ((_decoded_payload->>'platform_token')::uuid, _platform.token);
+            return next is ((_decoded_payload->>'role')::text, 'scoped_user');
+            return next is ((_decoded_payload->>'user_id')::uuid, __seed_first_user_id());
+            return next is ((_decoded_payload->>'scopes')::jsonb, to_jsonb('{admin}'::text[]));
+            return next is ((_result is not null), true);
+        end;
+    $$;
+    select test_with_user_api_key();
+
+    create or replace function test_with_user_disabled_api_key()
+    returns setof text language plpgsql as $$
+        declare
+            _platform platform_service.platforms;
+            _result text;
+            _decoded_payload json;
+        begin
+            select * from platform_service.platforms where id = __seed_platform_id() into _platform;
+
+            insert into community_service.user_api_keys(disabled_at, user_id, platform_id, token) values (now(), __seed_first_user_id(), _platform.id, 'user_api_key_dst3386b7962189c512a82e419c824d64fa89c4034a22904fd608913fbccc913d224a859149700ff0850af56a343fdb24b90');
+            _result := core.generate_access_jwt_from_api_key('user_api_key_dst3386b7962189c512a82e419c824d64fa89c4034a22904fd608913fbccc913d224a859149700ff0850af56a343fdb24b90');
+
+            return next is ((_result is null), true);
+        end;
+    $$;
+    select test_with_user_disabled_api_key();
 
     select * from finish();
 ROLLBACK;

--- a/specs/sql-specs/payment-service/function.is_confirmed_test.sql
+++ b/specs/sql-specs/payment-service/function.is_confirmed_test.sql
@@ -1,0 +1,47 @@
+-- Start transaction and plan the tests.
+BEGIN;
+    -- insert seed data for basic user/platform/project/reward
+    \i /specs/sql-support/insert_platform_user_project.sql
+
+    SELECT plan(3);
+
+    SELECT function_returns(
+        'payment_service', 'is_confirmed', ARRAY['payment_service.contributions'], 'boolean'
+    );
+
+    CREATE OR REPLACE FUNCTION test_is_confirmed()
+    returns setof text language plpgsql
+    as $$
+        declare
+            _contribution payment_service.contributions;
+            _unconfirmed_contribution payment_service.contributions;
+            _transition payment_service.payment_status_transitions;
+        begin
+            -- generate contribution
+            insert into payment_service.contributions
+                (platform_id, user_id, project_id, value, payer_email) 
+                values (__seed_platform_id(), __seed_first_user_id(), __seed_project_id(), 100, 'foo@bar.com')
+                returning * into _contribution;
+
+            insert into payment_service.contributions
+                (platform_id, user_id, project_id, value, payer_email) 
+                values (__seed_platform_id(), __seed_first_user_id(), __seed_project_id(), 100, 'foo@bar.com')
+                returning * into _unconfirmed_contribution;
+            -- generate payment
+            insert into payment_service.catalog_payments
+                (gateway, contribution_id, platform_id, user_id, project_id, status, data) 
+                values ('pagarme', _contribution.id, __seed_platform_id(), __seed_first_user_id(), __seed_project_id(), 'paid', '{}');
+
+            insert into payment_service.catalog_payments
+                (gateway, contribution_id, platform_id, user_id, project_id, status, data) 
+                values ('pagarme', _unconfirmed_contribution.id, __seed_platform_id(), __seed_first_user_id(), __seed_project_id(), 'refunded', '{}');
+
+            return next ok(payment_service.is_confirmed(_contribution.*) is true, 'expect to be true when payment was paid');
+            return next ok(payment_service.is_confirmed(_unconfirmed_contribution.*) is false, 'expect to be false if payment is refunded');
+        end;
+    $$;
+
+    select test_is_confirmed();
+
+    SELECT * FROM finish();
+ROLLBACK;

--- a/specs/sql-specs/payment-service/function.was_confirmed_test.sql
+++ b/specs/sql-specs/payment-service/function.was_confirmed_test.sql
@@ -1,0 +1,45 @@
+-- Start transaction and plan the tests.
+BEGIN;
+    -- insert seed data for basic user/platform/project/reward
+    \i /specs/sql-support/insert_platform_user_project.sql
+
+    SELECT plan(3);
+
+    SELECT function_returns(
+        'payment_service', 'was_confirmed', ARRAY['payment_service.contributions'], 'boolean'
+    );
+
+    CREATE OR REPLACE FUNCTION test_was_confirmed()
+    returns setof text language plpgsql
+    as $$
+        declare
+            _contribution payment_service.contributions;
+            _unpaid_contribution payment_service.contributions;
+            _payment payment_service.catalog_payments;
+            _transition payment_service.payment_status_transitions;
+        begin
+            -- generate contribution
+            insert into payment_service.contributions
+                (platform_id, user_id, project_id, value, payer_email) 
+                values (__seed_platform_id(), __seed_first_user_id(), __seed_project_id(), 100, 'foo@bar.com')
+                returning * into _contribution;
+
+            insert into payment_service.contributions
+                (platform_id, user_id, project_id, value, payer_email) 
+                values (__seed_platform_id(), __seed_first_user_id(), __seed_project_id(), 100, 'foo@bar.com')
+                returning * into _unpaid_contribution;
+            -- generate payment
+            insert into payment_service.catalog_payments
+                (gateway, contribution_id, platform_id, user_id, project_id, status, data) 
+                values ('pagarme', _contribution.id, __seed_platform_id(), __seed_first_user_id(), __seed_project_id(), 'refunded', '{}')
+                returning * into _payment;
+
+            return next ok(payment_service.was_confirmed(_contribution.*) is true, 'expect to be true when payment was refunded');
+            return next ok(payment_service.was_confirmed(_unpaid_contribution.*) is false, 'expect to be false if no payment');
+        end;
+    $$;
+
+    select test_was_confirmed();
+
+    SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
### Why

generate_jwt_from_api_key should accept platform_api_key / temp_login_api_key and user_api_key

### Wrap up checklist

- [x] All new code has tests
- [x] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
